### PR TITLE
fix: error when package already defined

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,11 +8,15 @@ class credstash(
     'debian' => 'python-yaml',
   }
 
-  package { 'python-yaml' :
-    name => $python_yaml_package_name,
+  if !defined(Package['python-yaml']) {
+    package { 'python-yaml' :
+      name => $python_yaml_package_name,
+    }
   }
 
-  package { 'python-crypto' : }
+  if !defined(Package['python-crypto']) {
+    package { 'python-crypto' : }
+  }
 
   python::pip { $credstash_package :
     require => [


### PR DESCRIPTION
We have cases in which we have to overide the `python-yaml` and `python-crypto` packages so support some of our systems. When we do that we get the following error. This should allow the package to be created if it is not already defined.

This is the error:
```
Error: Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Package[python-yaml] is already declared in file modules/wrappers/manifests/init.pp:86; cannot redeclare at modules/credstash/manifests/init.pp:12 at modules/credstash/manifests/init.pp:12:3 on node xxx
```